### PR TITLE
feat: Display cookie policy in a modal

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,15 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import ShoppingList from './ShoppingList';
 import LoginModal from './LoginModal';
-import CookiePolicy from './CookiePolicy';
 import CookieConsent from './components/CookieConsent/CookieConsent';
 import { useCookieConsentContext } from './context/CookieConsentContext';
-import { useRouter } from './context/RouterContext';
 
 function App() {
   const [user, setUser] = useState(null);
   const { openSettings } = useCookieConsentContext();
-  const { path } = useRouter(); // Get path from RouterContext
 
   useEffect(() => {
     const session = JSON.parse(localStorage.getItem('userSession'));
@@ -44,32 +41,19 @@ function App() {
     setIsLoginModalOpen(false);
   };
 
-  const renderPage = () => {
-    switch (path) {
-      case '/politica-de-cookies':
-        return <CookiePolicy />;
-      default:
-        return (
-          <>
-            <ShoppingList
-              user={user}
-              onLogout={handleLogout}
-              onLoginRedirect={() => setIsLoginModalOpen(true)}
-            />
-            {isLoginModalOpen && (
-              <LoginModal
-                onLogin={handleLoginSuccess}
-                onClose={() => setIsLoginModalOpen(false)}
-              />
-            )}
-          </>
-        );
-    }
-  };
-
   return (
     <div className="App">
-      {renderPage()}
+      <ShoppingList
+        user={user}
+        onLogout={handleLogout}
+        onLoginRedirect={() => setIsLoginModalOpen(true)}
+      />
+      {isLoginModalOpen && (
+        <LoginModal
+          onLogin={handleLoginSuccess}
+          onClose={() => setIsLoginModalOpen(false)}
+        />
+      )}
       <CookieConsent />
       <footer className="app-footer">
         <button onClick={openSettings} className="footer-link">

--- a/client/src/CookiePolicy.jsx
+++ b/client/src/CookiePolicy.jsx
@@ -1,17 +1,8 @@
 import React from 'react';
-import { useRouter } from './context/RouterContext';
 
 const CookiePolicy = () => {
-  const { navigate } = useRouter();
-
-  const handleBackClick = (e) => {
-    e.preventDefault();
-    navigate('/');
-  };
-
   return (
     <div className="policy-page">
-      <a href="/" onClick={handleBackClick} className="back-link">&larr; Volver a la página principal</a>
       <h1>Política de Cookies</h1>
       <p><em>Última actualización: 22 de septiembre de 2025</em></p>
 

--- a/client/src/CookiePolicyModal.jsx
+++ b/client/src/CookiePolicyModal.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import CookiePolicy from './CookiePolicy';
+import { useCookieConsentContext } from './context/CookieConsentContext';
+
+const CookiePolicyModal = () => {
+  const { closePolicy } = useCookieConsentContext();
+
+  return (
+    <div className="cookie-settings-overlay" role="dialog" aria-modal="true">
+      <div className="cookie-settings-modal">
+        <div className="modal-header">
+          <h2>Política de Cookies</h2>
+          <button onClick={closePolicy} className="close-button" aria-label="Cerrar">
+            &times;
+          </button>
+        </div>
+        <div className="modal-content">
+          <CookiePolicy />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookiePolicyModal;

--- a/client/src/components/CookieConsent/CookieConsent.jsx
+++ b/client/src/components/CookieConsent/CookieConsent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useCookieConsentContext } from '../../context/CookieConsentContext';
-import { useRouter } from '../../context/RouterContext';
+import CookiePolicyModal from '../../CookiePolicyModal';
 import './CookieConsent.css';
 
 const CookieConsent = () => {
@@ -8,17 +8,17 @@ const CookieConsent = () => {
     consent,
     isBannerVisible,
     isSettingsVisible,
+    isPolicyVisible,
     acceptAll,
     rejectAll,
     updateConsent,
     savePreferences,
     openSettings,
     closeSettings,
+    openPolicy,
   } = useCookieConsentContext();
 
-  const { navigate } = useRouter();
-
-  if (!isBannerVisible && !isSettingsVisible) {
+  if (!isBannerVisible && !isSettingsVisible && !isPolicyVisible) {
     return null;
   }
 
@@ -28,7 +28,7 @@ const CookieConsent = () => {
 
   const handlePolicyClick = (e) => {
     e.preventDefault();
-    navigate('/politica-de-cookies');
+    openPolicy();
   };
 
   const renderBanner = () => (
@@ -37,7 +37,7 @@ const CookieConsent = () => {
         <p>
           Utilizamos cookies para mejorar tu experiencia. Al aceptar, nos permites usar cookies de rendimiento para analizar el tráfico y detectar errores.
           {' '}
-          <a href="/politica-de-cookies" onClick={handlePolicyClick}>
+          <a href="#" onClick={handlePolicyClick}>
             Política de Cookies
           </a>
         </p>
@@ -55,7 +55,11 @@ const CookieConsent = () => {
       <div className="cookie-settings-modal">
         <h2>Configuración de Cookies</h2>
         <p>
-          Puedes gestionar tus preferencias de cookies a continuación. Las cookies necesarias no se pueden desactivar.
+          Puedes gestionar tus preferencias de cookies a continuación. Las cookies necesarias no se pueden desactivar. Para más detalles, consulta nuestra{' '}
+          <a href="#" onClick={handlePolicyClick}>
+            Política de Cookies
+          </a>
+          .
         </p>
 
         <div className="cookie-category">
@@ -91,6 +95,10 @@ const CookieConsent = () => {
       </div>
     </div>
   );
+
+  if (isPolicyVisible) {
+    return <CookiePolicyModal />;
+  }
 
   if (isSettingsVisible) {
     return renderSettings();

--- a/client/src/hooks/useCookieConsent.js
+++ b/client/src/hooks/useCookieConsent.js
@@ -11,6 +11,7 @@ export const useCookieConsent = () => {
   const [consent, setConsent] = useState(null);
   const [isBannerVisible, setIsBannerVisible] = useState(false);
   const [isSettingsVisible, setIsSettingsVisible] = useState(false);
+  const [isPolicyVisible, setIsPolicyVisible] = useState(false);
 
   useEffect(() => {
     try {
@@ -87,16 +88,27 @@ export const useCookieConsent = () => {
     setIsSettingsVisible(false);
   }, []);
 
+  const openPolicy = useCallback(() => {
+    setIsPolicyVisible(true);
+  }, []);
+
+  const closePolicy = useCallback(() => {
+    setIsPolicyVisible(false);
+  }, []);
+
 
   return {
     consent,
     isBannerVisible,
     isSettingsVisible,
+    isPolicyVisible,
     acceptAll,
     rejectAll,
     updateConsent,
     savePreferences,
     openSettings,
     closeSettings,
+    openPolicy,
+    closePolicy,
   };
 };

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1022,3 +1022,33 @@ h2 {
 .policy-page .back-link:hover {
   text-decoration: underline;
 }
+
+/* Cookie Policy Modal */
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #444;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: #ffa500;
+}
+
+.modal-header .close-button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #aaa;
+  cursor: pointer;
+}
+
+.modal-content {
+  max-height: 60vh;
+  overflow-y: auto;
+  text-align: left;
+  padding-right: 1rem; /* Space for scrollbar */
+}


### PR DESCRIPTION
Refactors the cookie policy display from a separate page to a modal with an internal scrollbar.

- Creates a `CookiePolicyModal` component.
- Adds state to `useCookieConsent` hook to manage modal visibility.
- Updates the `CookieConsent` banner and settings to open the modal.
- Removes the old routing logic for the cookie policy page.
- Adds CSS for the modal, ensuring the content is scrollable.